### PR TITLE
[DOCS]  Update `Process` / `Tech Direction` Sections for Tech Lead role

### DIFF
--- a/managers/engineering_manager.md
+++ b/managers/engineering_manager.md
@@ -31,7 +31,7 @@ It's the responsibility of the EM to ensure all of the following for their teams
 * Foster continuous improvement mindset amongst team
 * Challenge team to identify bottlenecks & ways of speeding up delivery
 * Ensure engineers are focused on the sprint & stories at hand
-* Ensure engineers understand how the work they are doing impacts objects and key results (OKRs) & wider company goals
+* Ensure engineers understand how the work they are doing impacts objects and key results (OKRs) & company priorities
 
 #### Meetings
 

--- a/roles/technical_lead.md
+++ b/roles/technical_lead.md
@@ -22,33 +22,48 @@ It's the responsibility of the TL to ensure all of the following:
 
 #### Goals & planning
 
-* Work with PM/EM/Designer to create key results for teams
+* Work with product managers (PM), engineering managers (EM), and designers to create key results for teams
 * Work with PM/Designer to suggest hypotheses & ways to validate them
 * Work with PM/Designer to discuss approach & whale scale (t-shirt sizes) of larger features - look for ways to break into smaller pieces that add value & discuss risks & mitigations
-* Ensure the team understands how the sprint & the stories in it ladder up into OKRs & the company priorities
+* Ensure the team understands how the sprint & the stories in it ladder up into objects and key results (OKRs) & company priorities
 * Lead necessary tradeoff decisions with the PM, Designer, and team
 
 #### Sprint coordination
 
-* Manage technical WIP & help with/raise blockers
+* Manage technical work in progress (WIP)
+* Be aware of potential blockers and help to clear those that may arise
 * Ensure engineers have clear focus
 * Ensure engineers pause to ask questions as necessary
 
 #### Tech direction
 
 * Advise on which tech debt the team needs to address
+  * Actively engage in regular conversation to understand pain points for team
+  * Be curious and vigilant in identifying tech debt that poses security or fiscal risk
 * Role model and mentor incremental improvement strategies
+  * Communicate value of these approaches
+  * Help engineers cultivate a natural tendency toward incremental development
 * Guide team in balance of addressing tech debt vs new features
-* Prioritize chores in the backlog
+  * Work with PM, EM, and designers to build cross-team buy-in
+  * Understand value intersections against company priority for both tech debt + feature development
 * Ensure high quality architecture & technical approach of features
-* Guide team towards the simplest solution
-* Act as tie breaker if necessary
+* Guide the team towards simple solutions
+* Act as tiebreaker if necessary
 * Ensure team is breaking features into vertical slices that add value rather than doing big upfront architecture
 * Ensure code quality, stability & UX speed as appropriate (experiments & prototypes may have different standards)
 * Coach & mentor engineers in technical development & good engineering practices
+* Delegate where possible, encouraging engineers' independence, autonomy, and strengths
+* Be flexible and leave ego at the door
+  * Aim to have a personal understanding of the tasks at hand and possible solutions
+  * Be willing to let go of your solution in favor of equally viable solutions from your team
+* Guide teams toward safer solutions if they are headed toward risk for themselves, the product, or the company
 
 #### Process
 
 * Works with EM, PM & designer to evolve Agile approach to fit team and project needs.
 * Work with PM to ensure epics & stories have a clear goal, are user focused & have clear acceptance criteria
 * Work with PM to ensure Stories are pre-refined & ready before team refinement
+* Work with PM to groom the backlog holistically
+  * Understand priority
+  * Factor in team capacity
+  * Identify ways to reduce complexity


### PR DESCRIPTION
Motivation for changes:

* https://github.com/Mariana-Tek/engineering-ladder/issues/9

Changes:

* Add some consistency of syntax between [Engineering Manager](https://github.com/Mariana-Tek/engineering-ladder/blob/master/managers/engineering_manager.md) and [Tech Lead](https://github.com/Mariana-Tek/engineering-ladder/blob/master/roles/technical_lead.md)
* Expand on `Process` section
* Expand on `Tech Direction` section